### PR TITLE
updated shell command to construct REKOR_SERVER in tips page

### DIFF
--- a/content/modules/ROOT/pages/10-tips.adoc
+++ b/content/modules/ROOT/pages/10-tips.adoc
@@ -17,7 +17,7 @@ image::tip-6.png[]
 Via script
 
 ----
-REKOR_SERVER=https://$(oc get route rekor-server -n rekor -o json | jq -r .spec.host)
+REKOR_SERVER=https://$(oc get ingress rekor-server -n trusted-artifact-signer  -o json  | jq -r '.spec.rules[0].host')
 curl $REKOR_SERVER/api/v1/log/publicKey > public.key
 oc exec vault-0 -n vault -- vault kv put kv/secrets/janusidp/rekor public_key="$(cat public.key)"
 ----


### PR DESCRIPTION
Constructed route in current demo deployment uses an Ingress that generates the Route.
The Namespace has also changed.

```shell
$ oc get route  -n trusted-artifact-signer   |grep rekor
```
```
rekor-server-7drhb    rekor-server-trusted-artifact-signer.apps.cluster-fqh6l.sandbox1227.opentlc.com    /      rekor-server    80-tcp       edge/Redirect   None
```

```shell 
$ oc get route  -n trusted-artifact-signer   rekor-server-7drhb -o json | jq .metadata.ownerReferences
```
```json
[
  {
    "apiVersion": "networking.k8s.io/v1",
    "controller": true,
    "kind": "Ingress",
    "name": "rekor-server",
    "uid": "6e9c354d-e200-4c86-a8fb-6f60ffa4f6b0"
  }
]
```
